### PR TITLE
Fix Recent Shows to show 5 most recent public shows

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,3 @@
+[user]
+	name = Parker Smith
+	email = parkermandfw@gmail.com

--- a/scripts/setup-git-author.sh
+++ b/scripts/setup-git-author.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+set -e
+
+repo_root="$(git rev-parse --show-toplevel)"
+git_dir="$(git rev-parse --git-dir)"
+include_path="../.gitconfig"
+
+if [ "$git_dir" != "$repo_root/.git" ]; then
+  include_path="$(realpath "$repo_root/.gitconfig")"
+fi
+
+current_include="$(git config --local --get include.path 2>/dev/null || true)"
+
+if [ "$current_include" = "$include_path" ] || [ "$current_include" = "$(realpath "$repo_root/.gitconfig" 2>/dev/null || echo "")" ]; then
+  echo "Git author config already set for this repository."
+else
+  git config --local include.path "$include_path"
+  echo "Configured git to use $repo_root/.gitconfig for author info."
+fi
+
+git config --local --get-regexp '^user\.' || true

--- a/src/components/global/Navbar.tsx
+++ b/src/components/global/Navbar.tsx
@@ -41,11 +41,8 @@ import { useCart } from "@/providers/CartProvider";
 import { CartIcon } from "./CartIcon";
 
 export function NavBar() {
-  const shows = api.shows.getAll.useQuery(
-    {
-      limit: 10,
-      orderByStartDate: "desc",
-    },
+  const shows = api.shows.getRecentPublic.useQuery(
+    { limit: 5 },
     {
       refetchOnMount: false,
       refetchOnWindowFocus: false,
@@ -76,13 +73,11 @@ export function NavBar() {
                 <ul className="grid gap-3 p-6 pt-1 md:w-[400px] lg:w-[500px] lg:grid-cols-[1fr_1fr]">
                   {shows.isLoading ? (
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                    [...Array(4)].map((_, i) => {
+                    [...Array(5)].map((_, i) => {
                       return <FakeListItem key={i} />;
                     })
                   ) : shows.data ? (
-                    shows.data
-                      ?.filter((s) => s.isPublic)
-                      .map((show: Show) => {
+                    shows.data.map((show: Show) => {
                         return (
                           <Link
                             href={`/photos/shows/${show.slug}`}

--- a/src/server/api/routers/shows.ts
+++ b/src/server/api/routers/shows.ts
@@ -75,6 +75,30 @@ export const showRouter = createTRPCRouter({
       });
       return shows.map((s) => fromPrisma(s));
     }),
+  getRecentPublic: publicProcedure
+    .input(
+      z.object({
+        limit: z.number().optional().default(5),
+      })
+    )
+    .query(async ({ ctx, input }): Promise<Show[]> => {
+      const rawShows = await ctx.prisma.show.findMany({
+        where: { isPublic: true, parentId: null },
+        orderBy: { createdAt: "desc" },
+        take: input.limit,
+      });
+      const childShows = await ctx.prisma.show.findMany({
+        where: { parentId: { in: rawShows.map((s) => s.id) } },
+        orderBy: { startDate: "asc" },
+      });
+      const showsWithChildren = rawShows.map((show) => ({
+        ...show,
+        children: childShows
+          .filter((s) => s.parentId === show.id)
+          .map((s) => fromPrisma(s, false)),
+      }));
+      return showsWithChildren.map((s) => fromPrisma(s));
+    }),
   getAll: publicProcedure
     .input(
       z.object({


### PR DESCRIPTION
## Summary
- Add `getRecentPublic` API that returns public top-level shows ordered by `createdAt` (newest first), limited to 5
- Update navbar "Recent Shows" dropdown to use the new endpoint instead of sorting by event `startDate`
- Add tracked `.gitconfig` and `scripts/setup-git-author.sh` so git commits in this repo use Parker Smith's identity

## Test plan
- [ ] Open navbar "Shows" dropdown and confirm up to 5 public shows appear
- [ ] Verify shows are ordered by when they were added, not event date
- [ ] Confirm private shows are excluded
- [ ] Run `./scripts/setup-git-author.sh` on a fresh clone and verify `git config --local --get-regexp '^user\.'` reflects Parker Smith


Made with [Cursor](https://cursor.com)