### PR TITLE
Fix Clerk failing to load on production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,8 @@ DISCORD_CLIENT_ID=""
 DISCORD_CLIENT_SECRET=""
 
 # Clerk (use development keys for Vercel Preview; production keys for Production)
+# Do not set NEXT_PUBLIC_CLERK_DOMAIN or NEXT_PUBLIC_CLERK_IS_SATELLITE in Vercel.
+# Satellite domain config is handled in src/lib/clerk-config.ts.
 # Preview deploys with production keys use Clerk satellite mode automatically.
 # In the Clerk dashboard, add your Vercel preview domain under Domains → Satellites,
 # or add https://*.vercel.app to allowed origins when using development keys.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,7 +9,9 @@ const config = {
   reactStrictMode: true,
   env: {
     NEXT_PUBLIC_VERCEL_ENV: process.env.VERCEL_ENV ?? "",
-    NEXT_PUBLIC_CLERK_DOMAIN: process.env.VERCEL_URL ?? "",
+    ...(process.env.VERCEL_ENV === "preview"
+      ? { NEXT_PUBLIC_CLERK_PREVIEW_DOMAIN: process.env.VERCEL_URL ?? "" }
+      : {}),
   },
 
   /**

--- a/src/lib/clerk-config.ts
+++ b/src/lib/clerk-config.ts
@@ -3,6 +3,7 @@ import { PRODUCTION_SITE_URL, isPreviewDeployment } from "@/lib/app-url";
 const DEV_CLERK_ACCOUNTS_URL = "https://big-sloth-75.accounts.dev/user";
 const PROD_CLERK_ACCOUNTS_URL =
   "https://accounts.natalielockhartphotos.com/user";
+const PRODUCTION_CLERK_DOMAIN = "natalielockhartphotos.com";
 
 const VERCEL_PREVIEW_ORIGIN = /^https:\/\/[a-z0-9-]+\.vercel\.app$/;
 
@@ -19,25 +20,41 @@ export function getClerkAccountsUrl() {
     : DEV_CLERK_ACCOUNTS_URL;
 }
 
+function getSatelliteClerkProps(domain: string) {
+  return {
+    isSatellite: true as const,
+    domain,
+    signInUrl: `${PRODUCTION_SITE_URL}/sign-in`,
+    signUpUrl: `${PRODUCTION_SITE_URL}/sign-up`,
+  };
+}
+
 export function getClerkProviderProps() {
   const allowedRedirectOrigins: (string | RegExp)[] = [
     "http://localhost:3000",
     PRODUCTION_SITE_URL,
+    "https://www.natalielockhartphotos.com",
     VERCEL_PREVIEW_ORIGIN,
   ];
 
-  const previewDomain =
-    process.env.NEXT_PUBLIC_CLERK_DOMAIN ?? process.env.VERCEL_URL;
+  if (usesProductionClerkKeys()) {
+    if (isPreviewDeployment()) {
+      const previewDomain =
+        process.env.NEXT_PUBLIC_CLERK_PREVIEW_DOMAIN ?? process.env.VERCEL_URL;
 
-  if (isPreviewDeployment() && usesProductionClerkKeys() && previewDomain) {
+      if (previewDomain) {
+        return {
+          ...getSatelliteClerkProps(previewDomain),
+          allowedRedirectOrigins,
+        };
+      }
+    }
+
     return {
-      isSatellite: true,
-      domain: previewDomain,
-      signInUrl: `${PRODUCTION_SITE_URL}/sign-in`,
-      signUpUrl: `${PRODUCTION_SITE_URL}/sign-up`,
+      ...getSatelliteClerkProps(PRODUCTION_CLERK_DOMAIN),
       allowedRedirectOrigins,
     };
   }
 
-  return { allowedRedirectOrigins };
+  return { isSatellite: false as const, allowedRedirectOrigins };
 }


### PR DESCRIPTION
## Summary
- Stop injecting `VERCEL_URL` as `NEXT_PUBLIC_CLERK_DOMAIN` on production builds, which caused Clerk to load from a non-existent `clerk.nats-photos-*.vercel.app` domain
- Explicitly configure production satellite mode with `natalielockhartphotos.com` so Clerk loads from `clerk.natalielockhartphotos.com`
- Scope preview-only `NEXT_PUBLIC_CLERK_PREVIEW_DOMAIN` to Vercel preview builds

## Test plan
- [ ] Deploy to production and confirm the site renders (no `Clerk: Failed to load Clerk` in console)
- [ ] Sign in on `www.natalielockhartphotos.com`
- [ ] Verify a Vercel preview deploy still authenticates correctly
- [ ] Remove `NEXT_PUBLIC_CLERK_DOMAIN` and `NEXT_PUBLIC_CLERK_IS_SATELLITE` from Vercel Production env if present


Made with [Cursor](https://cursor.com)