### PR TITLE
Fix Clerk link_domain error on production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,7 @@ DISCORD_CLIENT_SECRET=""
 
 # Clerk (use development keys for Vercel Preview; production keys for Production)
 # Do not set NEXT_PUBLIC_CLERK_DOMAIN or NEXT_PUBLIC_CLERK_IS_SATELLITE in Vercel.
-# Satellite domain config is handled in src/lib/clerk-config.ts.
+# Production uses the primary Clerk custom domain. Satellite mode is preview-only.
 # Preview deploys with production keys use Clerk satellite mode automatically.
 # In the Clerk dashboard, add your Vercel preview domain under Domains → Satellites,
 # or add https://*.vercel.app to allowed origins when using development keys.

--- a/src/lib/clerk-config.ts
+++ b/src/lib/clerk-config.ts
@@ -3,7 +3,6 @@ import { PRODUCTION_SITE_URL, isPreviewDeployment } from "@/lib/app-url";
 const DEV_CLERK_ACCOUNTS_URL = "https://big-sloth-75.accounts.dev/user";
 const PROD_CLERK_ACCOUNTS_URL =
   "https://accounts.natalielockhartphotos.com/user";
-const PRODUCTION_CLERK_DOMAIN = "natalielockhartphotos.com";
 
 const VERCEL_PREVIEW_ORIGIN = /^https:\/\/[a-z0-9-]+\.vercel\.app$/;
 
@@ -20,41 +19,59 @@ export function getClerkAccountsUrl() {
     : DEV_CLERK_ACCOUNTS_URL;
 }
 
-function getSatelliteClerkProps(domain: string) {
+function getPreviewSatelliteDomain() {
+  return process.env.NEXT_PUBLIC_CLERK_PREVIEW_DOMAIN ?? process.env.VERCEL_URL;
+}
+
+function getPreviewSatelliteProps() {
+  const previewDomain = getPreviewSatelliteDomain();
+
+  if (!previewDomain) {
+    return null;
+  }
+
   return {
     isSatellite: true as const,
-    domain,
+    domain: previewDomain,
     signInUrl: `${PRODUCTION_SITE_URL}/sign-in`,
     signUpUrl: `${PRODUCTION_SITE_URL}/sign-up`,
   };
 }
 
-export function getClerkProviderProps() {
-  const allowedRedirectOrigins: (string | RegExp)[] = [
+function getAllowedRedirectOrigins() {
+  return [
     "http://localhost:3000",
     PRODUCTION_SITE_URL,
     "https://www.natalielockhartphotos.com",
     VERCEL_PREVIEW_ORIGIN,
   ];
+}
 
-  if (usesProductionClerkKeys()) {
-    if (isPreviewDeployment()) {
-      const previewDomain =
-        process.env.NEXT_PUBLIC_CLERK_PREVIEW_DOMAIN ?? process.env.VERCEL_URL;
+export function shouldUsePreviewSatelliteMode() {
+  return (
+    usesProductionClerkKeys() &&
+    isPreviewDeployment() &&
+    Boolean(getPreviewSatelliteDomain())
+  );
+}
 
-      if (previewDomain) {
-        return {
-          ...getSatelliteClerkProps(previewDomain),
-          allowedRedirectOrigins,
-        };
-      }
-    }
+export function getClerkMiddlewareOptions() {
+  if (!shouldUsePreviewSatelliteMode()) {
+    return {};
+  }
 
+  return getPreviewSatelliteProps() ?? {};
+}
+
+export function getClerkProviderProps() {
+  const allowedRedirectOrigins = getAllowedRedirectOrigins();
+
+  if (shouldUsePreviewSatelliteMode()) {
     return {
-      ...getSatelliteClerkProps(PRODUCTION_CLERK_DOMAIN),
+      ...getPreviewSatelliteProps(),
       allowedRedirectOrigins,
     };
   }
 
-  return { isSatellite: false as const, allowedRedirectOrigins };
+  return { allowedRedirectOrigins };
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,6 +2,7 @@ import { clerkClient } from "@clerk/nextjs";
 import { getAuth, withClerkMiddleware } from "@clerk/nextjs/server";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
+import { getClerkMiddlewareOptions } from "./lib/clerk-config";
 import { HOSTNAME, isAdmin as isUserAdmin } from "./lib/utils";
 
 const publicPaths = [
@@ -52,7 +53,7 @@ export default withClerkMiddleware(async (request: NextRequest) => {
     }
   }
   return NextResponse.next();
-});
+}, getClerkMiddlewareOptions());
 
 // Stop Middleware running on static files
 export const config = {


### PR DESCRIPTION
## Summary
- Stop enabling Clerk satellite mode on production; `natalielockhartphotos.com` is the primary Clerk custom domain, not a satellite app
- Keep satellite auth only for Vercel preview deploys that run on `*.vercel.app`
- Pass matching middleware options for preview satellite mode

## Context
PR #11 fixed Clerk JS loading by setting production satellite mode, but that triggered `link_domain must be included` during satellite sync on prod. Production should use standard Clerk custom-domain auth instead.

## Test plan
- [ ] Deploy to production and confirm the navbar Login button appears (no infinite spinner)
- [ ] Sign in on `www.natalielockhartphotos.com` without `link_domain` errors
- [ ] Verify a Vercel preview deploy still authenticates when using production Clerk keys


Made with [Cursor](https://cursor.com)